### PR TITLE
Update Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,6 @@ WriteMakefile(
         'HTTP::Message' => 0,
         'Digest::SHA1' => 0,
         'MIME::Base64' => 0,
-        'MIME::tools' => 0,
+        'MIME::Tools' => 0,
     }
 );


### PR DESCRIPTION
Within Makefile.PL, one of the prerequsites has a typo which causes installation to fail. 
It's listed as MIME:tools rather than MIME::Tools.

https://rt.cpan.org/Ticket/Display.html?id=84214
